### PR TITLE
fix: handle Date/Buffer in docx templates

### DIFF
--- a/packages/api/src/__tests__/docx.test.ts
+++ b/packages/api/src/__tests__/docx.test.ts
@@ -58,6 +58,12 @@ describe("DocxService", () => {
 
             expect(processed.gallery[0].extension).toBe(".jpeg");
             expect(processed.gallery[1].img.extension).toBe(".png");
+
+            // Regression test for Issue #3 (Date/Null preservation)
+            const dateData = { date: new Date("2023-01-01"), empty: null };
+            const processedDate = (service as any).processDataForImages(dateData);
+            expect(processedDate.date).toBeInstanceOf(Date);
+            expect(processedDate.empty).toBeNull();
         });
     });
 

--- a/packages/api/src/services/docx.ts
+++ b/packages/api/src/services/docx.ts
@@ -65,6 +65,11 @@ export class DocxService {
             return data.map((item) => this.processDataForImages(item));
         }
 
+        // Fix for Issue #3: Preserve Date and Buffer objects
+        if (data instanceof Date || (typeof Buffer !== 'undefined' && Buffer.isBuffer(data))) {
+            return data;
+        }
+
         if (typeof data === "object") {
             const newData: any = {};
             for (const key in data) {


### PR DESCRIPTION
Fixes #3 where Date objects and Buffers were stripped into empty objects during image pre-processing, breaking templates that used them inside loops or data binding. Added regression test case.