### PR TITLE
feat: TemplateStorage abstraction layer

### DIFF
--- a/packages/api/src/routes/generate.ts
+++ b/packages/api/src/routes/generate.ts
@@ -91,6 +91,23 @@ export const generateRoutes = async (fastify: FastifyInstance) => {
     });
 
     f.get("/templates", async (request, reply) => {
-        return reply.status(200).send([]);
+        // TODO: Extract orgId from auth header (X-API-Key -> lookup)
+        // For now, use 'default' for self-hosted single-tenant mode
+        const orgId = 'default';
+
+        try {
+            const { getStorage } = await import('../storage/index.ts');
+            const storage = getStorage();
+            const templates = await storage.list(orgId);
+
+            return reply.status(200).send(templates.map(t => ({
+                id: t.id,
+                name: t.name,
+                required_fields: [] // TODO: Parse template to extract fields
+            })));
+        } catch (error) {
+            request.log.error({ error }, "Failed to list templates");
+            return reply.status(500).send({ error: "Failed to list templates" });
+        }
     });
 };

--- a/packages/api/src/storage/index.ts
+++ b/packages/api/src/storage/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Storage Factory - Creates the appropriate storage backend based on configuration
+ */
+
+import { TemplateStorage, StorageBackend } from './types';
+import { LocalFileStorage } from './local';
+
+// Re-export types
+export * from './types';
+export { LocalFileStorage } from './local';
+
+interface StorageConfig {
+    backend: StorageBackend;
+    // Local storage options
+    templatesDir?: string;
+    multiTenant?: boolean;
+    // Supabase options (for future implementation)
+    supabaseUrl?: string;
+    supabaseKey?: string;
+    // S3 options (for future implementation)
+    s3Bucket?: string;
+    s3Region?: string;
+}
+
+/**
+ * Create a storage instance based on environment configuration
+ */
+export function createStorage(config?: Partial<StorageConfig>): TemplateStorage {
+    const backend = config?.backend || (process.env.STORAGE_BACKEND as StorageBackend) || 'local';
+
+    switch (backend) {
+        case 'local':
+            const templatesDir = config?.templatesDir || process.env.TEMPLATES_DIR || './templates';
+            const multiTenant = config?.multiTenant || process.env.MULTI_TENANT === 'true';
+            return new LocalFileStorage(templatesDir, multiTenant);
+
+        case 'supabase':
+            // TODO: Implement SupabaseStorage
+            throw new Error('Supabase storage not yet implemented. Use STORAGE_BACKEND=local for now.');
+
+        case 's3':
+            // TODO: Implement S3Storage
+            throw new Error('S3 storage not yet implemented. Use STORAGE_BACKEND=local for now.');
+
+        case 'azure':
+            // TODO: Implement AzureStorage
+            throw new Error('Azure storage not yet implemented. Use STORAGE_BACKEND=local for now.');
+
+        default:
+            throw new Error(`Unknown storage backend: ${backend}`);
+    }
+}
+
+// Default storage instance (created lazily)
+let defaultStorage: TemplateStorage | null = null;
+
+export function getStorage(): TemplateStorage {
+    if (!defaultStorage) {
+        defaultStorage = createStorage();
+    }
+    return defaultStorage;
+}

--- a/packages/api/src/storage/local.ts
+++ b/packages/api/src/storage/local.ts
@@ -1,0 +1,101 @@
+/**
+ * LocalFileStorage - File system based storage for self-hosted deployments
+ * 
+ * Templates are stored in a local directory with optional org-based subdirectories.
+ * For single-tenant self-hosted mode, use orgId = 'default'.
+ */
+
+import { readdir, readFile, writeFile, unlink, stat, mkdir } from 'fs/promises';
+import { join, basename, extname } from 'path';
+import { Template, TemplateStorage } from './types';
+
+export class LocalFileStorage implements TemplateStorage {
+    private baseDir: string;
+    private multiTenant: boolean;
+
+    constructor(baseDir: string, multiTenant: boolean = false) {
+        this.baseDir = baseDir;
+        this.multiTenant = multiTenant;
+    }
+
+    private getOrgDir(orgId: string): string {
+        if (this.multiTenant) {
+            return join(this.baseDir, orgId);
+        }
+        // Single-tenant mode: all templates in root
+        return this.baseDir;
+    }
+
+    async list(orgId: string): Promise<Template[]> {
+        const dir = this.getOrgDir(orgId);
+
+        try {
+            const files = await readdir(dir);
+            const templates: Template[] = [];
+
+            for (const file of files) {
+                if (extname(file) === '.docx') {
+                    const filePath = join(dir, file);
+                    const stats = await stat(filePath);
+
+                    templates.push({
+                        id: file,
+                        name: basename(file, '.docx'),
+                        engine: 'word',
+                        source: file,
+                        createdAt: stats.birthtime,
+                        updatedAt: stats.mtime,
+                    });
+                }
+            }
+
+            return templates;
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                return [];
+            }
+            throw error;
+        }
+    }
+
+    async get(orgId: string, templateId: string): Promise<Buffer> {
+        const filePath = join(this.getOrgDir(orgId), templateId);
+        return readFile(filePath);
+    }
+
+    async put(orgId: string, templateId: string, file: Buffer, metadata?: Partial<Template>): Promise<Template> {
+        const dir = this.getOrgDir(orgId);
+
+        // Ensure directory exists
+        await mkdir(dir, { recursive: true });
+
+        const filePath = join(dir, templateId);
+        await writeFile(filePath, file);
+
+        const stats = await stat(filePath);
+
+        return {
+            id: templateId,
+            name: metadata?.name || basename(templateId, '.docx'),
+            engine: metadata?.engine || 'word',
+            source: templateId,
+            createdAt: stats.birthtime,
+            updatedAt: stats.mtime,
+        };
+    }
+
+    async delete(orgId: string, templateId: string): Promise<void> {
+        const filePath = join(this.getOrgDir(orgId), templateId);
+        await unlink(filePath);
+    }
+
+    async exists(orgId: string, templateId: string): Promise<boolean> {
+        const filePath = join(this.getOrgDir(orgId), templateId);
+        try {
+            await stat(filePath);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+}

--- a/packages/api/src/storage/types.ts
+++ b/packages/api/src/storage/types.ts
@@ -1,0 +1,46 @@
+/**
+ * TemplateStorage - Abstract interface for template storage backends
+ * 
+ * Supports multiple backends for self-hosted and SaaS deployments:
+ * - Local: File system storage for self-hosted/air-gapped environments
+ * - Supabase: Supabase Storage for SaaS multi-tenant deployments
+ * - S3: AWS S3 or compatible (R2, MinIO) for enterprise deployments
+ */
+
+export interface Template {
+    id: string;
+    name: string;
+    engine: 'word' | 'web';
+    source: string;
+    createdAt?: Date;
+    updatedAt?: Date;
+}
+
+export interface TemplateStorage {
+    /**
+     * List all templates for an organization
+     */
+    list(orgId: string): Promise<Template[]>;
+
+    /**
+     * Get template file buffer
+     */
+    get(orgId: string, templateId: string): Promise<Buffer>;
+
+    /**
+     * Upload a new template
+     */
+    put(orgId: string, templateId: string, file: Buffer, metadata?: Partial<Template>): Promise<Template>;
+
+    /**
+     * Delete a template
+     */
+    delete(orgId: string, templateId: string): Promise<void>;
+
+    /**
+     * Check if a template exists
+     */
+    exists(orgId: string, templateId: string): Promise<boolean>;
+}
+
+export type StorageBackend = 'local' | 'supabase' | 's3' | 'azure';


### PR DESCRIPTION
Implements the `TemplateStorage` abstraction layer as defined in spec.md Section 4.3.

## Added
- `packages/api/src/storage/types.ts`: Interface definitions
- `packages/api/src/storage/local.ts`: LocalFileStorage for self-hosted deployments
- `packages/api/src/storage/index.ts`: Factory function

## Changed
- `GET /v1/templates` now uses the storage layer to list templates

Closes #7