### PR TITLE
feat: add Railway deployment configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Dependencies
+node_modules
+.bun
+
+# Git
+.git
+.gitignore
+
+# Test files
+*.test.ts
+__tests__
+
+# Local env files
+.env
+.env.*
+
+# Build artifacts
+dist
+*.log
+
+# IDE
+.vscode
+.idea
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Test outputs
+*.pdf
+test-*.json

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,21 +1,42 @@
-FROM node:20-alpine AS base
+# Build stage - use official Bun image
+FROM oven/bun:1 AS builder
 
 WORKDIR /app
 
-# Copy the entire monorepo structure
-COPY package.json bun.lockb* bunfig.toml tsconfig.json ./
-COPY packages/shared packages/shared
-COPY packages/api packages/api
+# Copy package files from root
+COPY package.json bun.lock ./
+COPY packages/api/package.json ./packages/api/
 
-# Install Bun (for package management compatibility)
-RUN npm install -g bun
+# Install dependencies
+RUN bun install --frozen-lockfile
 
-# Install dependencies using Bun
-RUN bun install --ci
+# Copy source code
+COPY packages/api ./packages/api
+COPY tsconfig.json ./
 
-# Expose the API port
-EXPOSE 8080
+# Production stage - slim image
+FROM oven/bun:1-slim
 
-# Start the server using npm start (which uses tsx via Node)
+WORKDIR /app
+
+# Copy from builder
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/api ./packages/api
+COPY --from=builder /app/package.json ./
+
+# Create templates directory
+RUN mkdir -p /app/packages/api/templates
+
+# Copy templates
+COPY packages/api/templates ./packages/api/templates
+
 WORKDIR /app/packages/api
-CMD ["npm", "start"]
+
+# Railway uses PORT env var
+ENV PORT=3000
+
+# Expose port
+EXPOSE 3000
+
+# Start the server
+CMD ["bun", "run", "src/index.ts"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "packages/api/Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
Adds Railway deployment configuration for the Velocidoc API.

## Changes
- **Dockerfile**: Updated to use official Bun image with multi-stage build for smaller production image
- **railway.toml**: Railway service configuration with health checks
- **.dockerignore**: Excludes unnecessary files from Docker build

## Deployment Steps
1. Create a new project on [Railway](https://railway.app)
2. Connect this GitHub repo
3. Add a **Gotenberg** service using Docker image: `gotenberg/gotenberg:8`
4. Set environment variables:
   - `GOTENBERG_URL=http://gotenberg.railway.internal:3000`
   - `AUTH_ENABLED=true`
   - `API_KEYS=your-production-key`
5. Deploy!

## Testing
After deployment:
```bash
curl https://your-app.railway.app/health
```